### PR TITLE
Add timeout to the ipmitool invocation.

### DIFF
--- a/lib/facter/bmc.rb
+++ b/lib/facter/bmc.rb
@@ -55,7 +55,12 @@ def parse_laninfo
 end
 
 def ipmitool
-  @ipmitool ||= Facter::Core::Execution.which('ipmitool')
+  if !@ipmitool
+    timeout = Facter::Core::Execution.which('timeout')
+    ipmitool = Facter::Core::Execution.which('ipmitool')
+    @ipmitool = "#{timeout} 2 #{ipmitool}"
+  end
+  @ipmitool
 end
 
 def ip


### PR DESCRIPTION
It's possible for ipmitool to block forever reading /dev/ipmi0, and facter
does not do a good job of reaping the processes at timeout
(https://tickets.puppetlabs.com/browse/FACT-150)
so to avoid having 100s of ipmitool processes stacking up, I've added the timeout
to the shell command we invoke.